### PR TITLE
[ResponseOps] allow Slack API URL to be overridden for functional tests

### DIFF
--- a/x-pack/plugins/stack_connectors/common/slack_api/constants.ts
+++ b/x-pack/plugins/stack_connectors/common/slack_api/constants.ts
@@ -6,4 +6,3 @@
  */
 
 export const SLACK_API_CONNECTOR_ID = '.slack_api';
-export const SLACK_URL = 'https://slack.com/api/';

--- a/x-pack/plugins/stack_connectors/common/slack_api/lib.ts
+++ b/x-pack/plugins/stack_connectors/common/slack_api/lib.ts
@@ -77,3 +77,15 @@ export function retryResultSeconds(
     serviceMessage: message,
   };
 }
+
+// This is only modifiable via config, at startup.  The reason we
+// added this was to test with a local simulator for functional tests.
+let SlackApiUrl = 'https://slack.com/api/';
+
+export function internalSetSlackApiURL(url: string): void {
+  SlackApiUrl = url;
+}
+
+export function internalGetSlackApiURL(): string {
+  return SlackApiUrl;
+}

--- a/x-pack/plugins/stack_connectors/server/connector_types/slack_api/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/slack_api/index.ts
@@ -21,10 +21,11 @@ import type {
   SlackApiSecrets,
 } from '../../../common/slack_api/types';
 import { SlackApiSecretsSchema, SlackApiParamsSchema } from '../../../common/slack_api/schema';
-import { SLACK_API_CONNECTOR_ID, SLACK_URL } from '../../../common/slack_api/constants';
+import { SLACK_API_CONNECTOR_ID } from '../../../common/slack_api/constants';
 import { SLACK_CONNECTOR_NAME } from './translations';
 import { api } from './api';
 import { createExternalService } from './service';
+import { internalGetSlackApiURL } from '../../../common/slack_api/lib';
 
 const supportedSubActions = ['getChannels', 'postMessage'];
 
@@ -53,7 +54,7 @@ const validateSlackUrl = (secretsObject: SlackApiSecrets, validatorServices: Val
   const { configurationUtilities } = validatorServices;
 
   try {
-    configurationUtilities.ensureUriAllowed(SLACK_URL);
+    configurationUtilities.ensureUriAllowed(internalGetSlackApiURL());
   } catch (allowedListError) {
     throw new Error(
       i18n.translate('xpack.stackConnectors.slack_api.configurationError', {

--- a/x-pack/plugins/stack_connectors/server/connector_types/slack_api/service.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/slack_api/service.ts
@@ -26,8 +26,9 @@ import {
   errorResult,
   successResult,
 } from '../../../common/slack_api/lib';
-import { SLACK_API_CONNECTOR_ID, SLACK_URL } from '../../../common/slack_api/constants';
+import { SLACK_API_CONNECTOR_ID } from '../../../common/slack_api/constants';
 import { getRetryAfterIntervalFromHeaders } from '../lib/http_response_retry_header';
+import { internalGetSlackApiURL } from '../../../common/slack_api/lib';
 
 const buildSlackExecutorErrorResponse = ({
   slackApiError,
@@ -112,7 +113,7 @@ export const createExternalService = (
   }
 
   const axiosInstance = axios.create({
-    baseURL: SLACK_URL,
+    baseURL: internalGetSlackApiURL(),
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-type': 'application/json; charset=UTF-8',


### PR DESCRIPTION
# Not intended to be merged directly

## Summary


This is part of the effort to get the Slack API functional tests going.  For that, we need to allow
the Slack API URL, which before was hard-coded, to be updated so that it can be set to point to
the Slack API simulator server we will eventually create.

I first tried making this a config setting for `stack_connectors` - but I could see that was going to be messy - we'd have to know the port of the server before actually starting the functional test server, which starts the server simulators.  But ... the port may end up being determined dynamically, so ... there's no way to know it.

I ended up making the URL updateable via a new function, removed the existing `const` of the value, and changed those references to use the new function which returns the updateable value - `internalGetSlackApiURL()`.

All we should have to do to start using this, is call the `internalSetSlackApiURL()` function with the URL of the slack API simulator, once we know it.  I didn't expose the function any further up the directory tree, as I wasn't sure we would need to.  Guessing we may, as we will have to call this from the `x-pack/test` modules that create the slack API simulator.
